### PR TITLE
One line fix for building on OS X

### DIFF
--- a/npc.h
+++ b/npc.h
@@ -133,7 +133,7 @@ struct npc_opinion {
  npc_opinion(signed char T, signed char F, signed char V, signed char A, int O):
              trust (T), fear (F), value (V), anger(A), owed (O) { };
 
- npc_opinion(npc_opinion &copy)
+ npc_opinion(const npc_opinion &copy)
  {
   trust = copy.trust;
   fear = copy.fear;


### PR DESCRIPTION
Apple ships a very old GCC (4.2).  This one line change (const ref in npc_opinion constructor) is the only thing I needed to change for simply typing "make" to build a working executable on OS X using the stock GCC. (I may have necessary libraries, like curses, installed via homebrew, I didn't even check any dependencies, it just worked)
