### PR TITLE
This fix has been floating around the forums for a while, doesn't seem to have made it into the main repo.

### DIFF
--- a/game.cpp
+++ b/game.cpp
@@ -3098,9 +3098,11 @@ void game::monmove()
      }
     }
    }
-   if (!okay)
+   if (!okay) {
     z[i].dead = true;
+    break;
     //build_monmap();
+   }
   }
 
   if (!z[i].dead) {


### PR DESCRIPTION
Changed monmove() to break if it can't find a valid location for
the monster rather than looping infinitely. Diff thanks to Rick
on the Cataclysm forums.
