### PR TITLE
Fix typo in ammo description

### DIFF
--- a/itypedef.cpp
+++ b/itypedef.cpp
@@ -1672,7 +1672,7 @@ popular round in sub-machine guns.",
 AMMO("9mm +P",		 8, 380,AT_9MM,		c_ltblue,	STEEL,
 	 1,  7, 20,  4, 14, 15, 14,  25, "\
 Attempts to improve the ballistics of 9mm ammunition lead to high pressure\n\
-rounds.  Increased velocity resullts in superior accuracy and damage.",
+rounds.  Increased velocity results in superior accuracy and damage.",
 0);
 
 //  NAME		RAR PRC TYPE		COLOR		MAT


### PR DESCRIPTION
Fix "resullts" typo in 9mm +P ammo description
